### PR TITLE
Fixed Issue: Calling start and then end too quickly causes dismiss to fail

### DIFF
--- a/Progress/Classes/Prog.swift
+++ b/Progress/Classes/Prog.swift
@@ -22,6 +22,11 @@ public final class Prog {
     internal var progressors: [[Progressor]] = []
     internal var maxEndingAnimationDuration: TimeInterval = 0.4
     internal var fadingDuration: TimeInterval = 0.2
+    internal var competedAnimation = false {
+        didSet {
+            
+        }
+    }
     
     // MARK: - Progressors
     var builtInProgressorTypes: [String: Progressor.Type] = [
@@ -113,6 +118,7 @@ public final class Prog {
             print("\(parent) is already in progress")
             return
         }
+        shared.competedAnimation = false
         shared.progressParents.append(parent)
         shared.progressors.append([])
         
@@ -122,6 +128,11 @@ public final class Prog {
     }
     
     static func recursiveStart(in parent: ProgressParent, remainingTypes: [ProgressorType], completion: @escaping (()->Void)) {
+        if shared.competedAnimation {
+            shared.competedAnimation = true
+            completion()
+        }
+        
         if let type = remainingTypes.first {
             start(in: parent, type: type) {
                 var remain = remainingTypes
@@ -172,13 +183,14 @@ public final class Prog {
      - parameter completion: callback function after all the ending animation
      */
     public static func end(in parent: ProgressParent, completion: @escaping (()->Void) = {}) {
-        recursiveEnd(in: parent, remainingProgressors: progressors(of: parent).reversed()) { 
-            if let index = shared.progressParents.index(where: { $0 === parent}) {
-                shared.progressParents.remove(at: index)
-                shared.progressors.remove(at: index)
+        shared.competedAnimation = true
+            recursiveEnd(in: parent, remainingProgressors: progressors(of: parent).reversed()) {
+                if let index = shared.progressParents.index(where: { $0 === parent}) {
+                    shared.progressParents.remove(at: index)
+                    shared.progressors.remove(at: index)
+                }
+                completion()
             }
-            completion()
-        }
     }
     
     static func recursiveEnd(in parent: ProgressParent, remainingProgressors: [Progressor], completion: @escaping (()->Void)) {

--- a/Progress/Classes/Prog.swift
+++ b/Progress/Classes/Prog.swift
@@ -22,11 +22,7 @@ public final class Prog {
     internal var progressors: [[Progressor]] = []
     internal var maxEndingAnimationDuration: TimeInterval = 0.4
     internal var fadingDuration: TimeInterval = 0.2
-    internal var competedAnimation = false {
-        didSet {
-            
-        }
-    }
+    internal var competedAnimation = false
     
     // MARK: - Progressors
     var builtInProgressorTypes: [String: Progressor.Type] = [


### PR DESCRIPTION
"Calling start and then end too quickly causes dismiss to fail" has been fixed.

No need change in any calling methods or parameters